### PR TITLE
use chef_gem and install depends at compile time, version bump

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,8 @@ maintainer_email "ops@dnsimple.com"
 license          "Apache 2.0"
 description      "Installs/Configures dnsimple"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.4.0"
+version          "0.4.1"
 
 recipe   "dnsimple", "Installs fog gem to use w/ the dnsimple_record"
 supports "ubuntu"
+

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: dnsimple
 # Recipe:: default
 #
-# Copyright 2010, Heavy Water Software Inc.
+# Copyright 2012, Heavy Water Operations, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,10 +17,15 @@
 # limitations under the License.
 #
 
-gem_package "fog" do
+%w{ build-essential libxml2-dev libxslt1-dev }.each do |p|
+  package p do
+    action :nothing
+  end.run_action( :install )
+end
+
+chef_gem "fog" do
   version node['dnsimple']['fog_version']
-  action :nothing
-end.run_action( :install )
+end
 
 require 'rubygems'
 Gem.clear_paths


### PR DESCRIPTION
Small changes to use new chef_gem resource. Also, don't assume dependencies exist. 

Instead of installed dependencies here, we could make changes to the xml and build-essential cookbooks to ensure both support compile time installation of packages.
